### PR TITLE
Add unit tests for ConfigManager

### DIFF
--- a/src/ConfigManager.cpp
+++ b/src/ConfigManager.cpp
@@ -6,9 +6,6 @@
 
 namespace
 {
-    // configuration file path
-    static constexpr char g_configFilePath[] = CONFIG_FILE_PATH;
-
     // language support
     static constexpr char g_languageSupport[] = "Language Support";
     static constexpr char g_english[] = "English";
@@ -30,11 +27,11 @@ namespace
 
 namespace embeddedIntentRecognizer
 {
-    bool ConfigManager::loadConfig(ApplicationConfig &configuration) const
+    bool ConfigManager::loadConfig(ApplicationConfig &configuration, const char configFilePath[]) const
     {
         std::cout << "[INFO]: Loading Application Configuration..\n";
 
-        const bool state = readConfig(configuration);
+        const bool state = readConfig(configuration, configFilePath);
         if (!state)
         {
             std::cout << "[ERROR]: Failed to load Application Configuration.\n";
@@ -45,10 +42,10 @@ namespace embeddedIntentRecognizer
         return true;
     }
 
-    bool ConfigManager::readConfig(ApplicationConfig &configuration) const
+    bool ConfigManager::readConfig(ApplicationConfig &configuration, const char configFilePath[]) const
     {
         std::ostringstream documentBuffer;
-        std::ifstream file{g_configFilePath};
+        std::ifstream file{configFilePath};
         documentBuffer << file.rdbuf();
 
         rapidjson::Document configFile;

--- a/src/ConfigManager.hpp
+++ b/src/ConfigManager.hpp
@@ -4,15 +4,22 @@
 #include "rapidjson/include/rapidjson/document.h"
 #include "common/Types.hpp"
 
+namespace
+{
+    // configuration file path
+    static constexpr char g_configFilePath[] = CONFIG_FILE_PATH;
+
+} // anonymous namespace
+
 namespace embeddedIntentRecognizer
 {
     class ConfigManager
     {
     public:
-        bool loadConfig(ApplicationConfig &configuration) const;
+        bool loadConfig(ApplicationConfig &configuration, const char configFilePath[] = g_configFilePath) const;
 
     private:
-        bool readConfig(ApplicationConfig &configuration) const;
+        bool readConfig(ApplicationConfig &configuration, const char configFilePath[]) const;
         bool fillLanguageConfiguration(const std::string &inLanguage, SupportedLanguages &language) const;
         bool fillInputDeviceConfiguration(const std::string &inInputDevice, SupportedInputs &inputDevice) const;
         bool fillOutputDeviceConfiguration(const rapidjson::Value::ConstArray &outDevices, ApplicationConfig &configuration) const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,11 +34,33 @@ add_definitions(
     "-DENGLISH_DATA_SET5_FILE_PATH=\"${CMAKE_SOURCE_DIR}/data/english-dataSet/${DATA_SET_5}\""
 )
 
+# define several configuration files for unit tests
+set(TEST_INVALID_FORMAT1_CFG_FILE "invalid-format1.cfg")
+set(TEST_INVALID_FORMAT2_CFG_FILE "invalid-format2.cfg")
+set(TEST_INVALID_FORMAT3_CFG_FILE "invalid-format3.cfg")
+set(TEST_INVALID_FORMAT4_CFG_FILE "invalid-format4.cfg")
+set(TEST_VALID_FORMAT1_CFG_FILE "valid-format1.cfg")
+set(TEST_VALID_FORMAT2_CFG_FILE "valid-format2.cfg")
+set(TEST_VALID_FORMAT3_CFG_FILE "valid-format3.cfg")
+set(TEST_VALID_FORMAT4_CFG_FILE "valid-format4.cfg")
+
+add_definitions(
+    "-DTEST_INVALID_FORMAT1_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_INVALID_FORMAT1_CFG_FILE}\""
+    "-DTEST_INVALID_FORMAT2_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_INVALID_FORMAT2_CFG_FILE}\""
+    "-DTEST_INVALID_FORMAT3_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_INVALID_FORMAT3_CFG_FILE}\""
+    "-DTEST_INVALID_FORMAT4_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_INVALID_FORMAT4_CFG_FILE}\""
+    "-DTEST_VALID_FORMAT1_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_VALID_FORMAT1_CFG_FILE}\""
+    "-DTEST_VALID_FORMAT2_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_VALID_FORMAT2_CFG_FILE}\""
+    "-DTEST_VALID_FORMAT3_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_VALID_FORMAT3_CFG_FILE}\""
+    "-DTEST_VALID_FORMAT4_FILE_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/test-artifacts/${TEST_VALID_FORMAT4_CFG_FILE}\""
+)
+
 # set executable source files
 set(EIR_TEST_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/EmbeddedIntentRecognizerTest.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TextProcessorTest.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ConfigManagerTest.cpp
 
     ${CMAKE_SOURCE_DIR}/src/EmbeddedIntentRecognizer.cpp
     ${CMAKE_SOURCE_DIR}/src/ConfigManager.cpp

--- a/tests/ConfigManagerTest.cpp
+++ b/tests/ConfigManagerTest.cpp
@@ -1,0 +1,102 @@
+#include "gtest/gtest.h"
+
+#include "ConfigManager.hpp"
+
+namespace embeddedIntentRecognizer_unit_test
+{
+    namespace
+    {
+        using namespace embeddedIntentRecognizer;
+
+        // configuration files' paths used in test cases
+        static constexpr char g_invalidFormat1FilePath[] = TEST_INVALID_FORMAT1_FILE_PATH;
+        static constexpr char g_invalidFormat2FilePath[] = TEST_INVALID_FORMAT2_FILE_PATH;
+        static constexpr char g_invalidFormat3FilePath[] = TEST_INVALID_FORMAT3_FILE_PATH;
+        static constexpr char g_invalidFormat4FilePath[] = TEST_INVALID_FORMAT4_FILE_PATH;
+
+        static constexpr char g_validFormat1FilePath[] = TEST_VALID_FORMAT1_FILE_PATH;
+        static constexpr char g_validFormat2FilePath[] = TEST_VALID_FORMAT2_FILE_PATH;
+        static constexpr char g_validFormat3FilePath[] = TEST_VALID_FORMAT3_FILE_PATH;
+        static constexpr char g_validFormat4FilePath[] = TEST_VALID_FORMAT4_FILE_PATH;
+
+    } // anonymous namespace
+
+    class ConfigManagerTest : public ::testing::Test
+    {
+    public:
+        ConfigManagerTest() = default;
+        ~ConfigManagerTest() override = default;
+
+        void SetUp() override {}
+        void TearDown() override {}
+
+        ApplicationConfig appConfig;
+
+        ConfigManager configManager;
+    };
+
+    TEST_F(ConfigManagerTest, Test_invalidFormatConfigFile1)
+    {
+        EXPECT_FALSE(configManager.loadConfig(appConfig, g_invalidFormat1FilePath));
+    }
+
+    TEST_F(ConfigManagerTest, Test_invalidFormatConfigFile2)
+    {
+        EXPECT_FALSE(configManager.loadConfig(appConfig, g_invalidFormat2FilePath));
+    }
+
+    TEST_F(ConfigManagerTest, Test_invalidFormatConfigFil3)
+    {
+        EXPECT_FALSE(configManager.loadConfig(appConfig, g_invalidFormat3FilePath));
+    }
+
+    TEST_F(ConfigManagerTest, Test_invalidFormatConfigFil4)
+    {
+        EXPECT_FALSE(configManager.loadConfig(appConfig, g_invalidFormat4FilePath));
+    }
+
+    TEST_F(ConfigManagerTest, Test_validFormatConfigFile1)
+    {
+        EXPECT_TRUE(configManager.loadConfig(appConfig, g_validFormat1FilePath));
+
+        EXPECT_EQ(appConfig.language, SupportedLanguages::ENGLISH);
+        EXPECT_EQ(appConfig.inputType, SupportedInputs::CLI_INPUT);
+        EXPECT_TRUE(appConfig.cliOutput);
+        EXPECT_FALSE(appConfig.touchScreenOutput);
+        EXPECT_FALSE(appConfig.voiceOutput);
+    }
+
+    TEST_F(ConfigManagerTest, Test_validFormatConfigFile2)
+    {
+        EXPECT_TRUE(configManager.loadConfig(appConfig, g_validFormat2FilePath));
+
+        EXPECT_EQ(appConfig.language, SupportedLanguages::DEUTSCH);
+        EXPECT_EQ(appConfig.inputType, SupportedInputs::TOUCH_SCREEN_INPUT);
+        EXPECT_TRUE(appConfig.cliOutput);
+        EXPECT_FALSE(appConfig.touchScreenOutput);
+        EXPECT_FALSE(appConfig.voiceOutput);
+    }
+
+    TEST_F(ConfigManagerTest, Test_validFormatConfigFile3)
+    {
+        EXPECT_TRUE(configManager.loadConfig(appConfig, g_validFormat3FilePath));
+
+        EXPECT_EQ(appConfig.language, SupportedLanguages::ENGLISH);
+        EXPECT_EQ(appConfig.inputType, SupportedInputs::VOICE_INPUT);
+        EXPECT_FALSE(appConfig.cliOutput);
+        EXPECT_FALSE(appConfig.touchScreenOutput);
+        EXPECT_TRUE(appConfig.voiceOutput);
+    }
+
+    TEST_F(ConfigManagerTest, Test_validFormatConfigFile4)
+    {
+        EXPECT_TRUE(configManager.loadConfig(appConfig, g_validFormat4FilePath));
+
+        EXPECT_EQ(appConfig.language, SupportedLanguages::DEUTSCH);
+        EXPECT_EQ(appConfig.inputType, SupportedInputs::CLI_INPUT);
+        EXPECT_TRUE(appConfig.cliOutput);
+        EXPECT_TRUE(appConfig.touchScreenOutput);
+        EXPECT_TRUE(appConfig.voiceOutput);
+    }
+
+} // namespace embeddedIntentRecognizer_unit_test

--- a/tests/EmbeddedIntentRecognizerTest.cpp
+++ b/tests/EmbeddedIntentRecognizerTest.cpp
@@ -13,21 +13,11 @@ namespace embeddedIntentRecognizer_unit_test
     class EmbeddedIntentRecognizerTest : public ::testing::Test
     {
     public:
-        EmbeddedIntentRecognizerTest()
-        {
-        }
+        EmbeddedIntentRecognizerTest() = default;
+        ~EmbeddedIntentRecognizerTest() override = default;
 
-        ~EmbeddedIntentRecognizerTest() override
-        {
-        }
-
-        void SetUp() override
-        {
-        }
-
-        void TearDown() override
-        {
-        }
+        void SetUp() override {}
+        void TearDown() override {}
 
         EmbeddedIntentRecognizer embeddedIntentRecognizer;
     };

--- a/tests/TextProcessorTest.cpp
+++ b/tests/TextProcessorTest.cpp
@@ -1,4 +1,3 @@
-#include <array>
 #include <memory>
 #include "gtest/gtest.h"
 

--- a/tests/test-artifacts/invalid-format1.cfg
+++ b/tests/test-artifacts/invalid-format1.cfg
@@ -1,0 +1,4 @@
+{
+    "Language Support" : "English",
+    "Input Device" : "CLI",
+    "Output Devices" : ["CLI"]

--- a/tests/test-artifacts/invalid-format2.cfg
+++ b/tests/test-artifacts/invalid-format2.cfg
@@ -1,0 +1,5 @@
+{
+    "Language Support" : "English",
+    "Input Device" : "CLI",
+    "Output Devices" : []
+}

--- a/tests/test-artifacts/invalid-format3.cfg
+++ b/tests/test-artifacts/invalid-format3.cfg
@@ -1,0 +1,5 @@
+{
+    "Language Support" : "English",
+    "Input Device" : "CLI",
+    "Output Devices" : [""]
+}

--- a/tests/test-artifacts/invalid-format4.cfg
+++ b/tests/test-artifacts/invalid-format4.cfg
@@ -1,0 +1,5 @@
+{
+    "Language Support" : "English",
+    "Input Device" : CLI,
+    "Output Devices" : ["CLI"]
+}

--- a/tests/test-artifacts/valid-format1.cfg
+++ b/tests/test-artifacts/valid-format1.cfg
@@ -1,0 +1,5 @@
+{
+    "Language Support" : "English",
+    "Input Device" : "CLI",
+    "Output Devices" : ["CLI"]
+}

--- a/tests/test-artifacts/valid-format2.cfg
+++ b/tests/test-artifacts/valid-format2.cfg
@@ -1,0 +1,5 @@
+{
+    "Language Support" : "Deutsch",
+    "Input Device" : "Touch Screen",
+    "Output Devices" : ["CLI"]
+}

--- a/tests/test-artifacts/valid-format3.cfg
+++ b/tests/test-artifacts/valid-format3.cfg
@@ -1,0 +1,5 @@
+{
+    "Language Support" : "English",
+    "Input Device" : "Voice Input",
+    "Output Devices" : ["Touch Screen", "invalid name"]
+}

--- a/tests/test-artifacts/valid-format4.cfg
+++ b/tests/test-artifacts/valid-format4.cfg
@@ -1,0 +1,7 @@
+{
+    "Language Support" : "Deutsch",
+
+    "Input Device" : "CLI",
+
+    "Output Devices" : ["Touch Screen", "Voice Output","CLI"]
+}


### PR DESCRIPTION
1- Add test cases that cover valid and invalid configuration files formats
2- Add custom configuration files for covering each test case
3- Move the configuration file path to header file and add it as default parameter
to init method for testability of configManager class